### PR TITLE
Error message format fix

### DIFF
--- a/src/PDFShift.php
+++ b/src/PDFShift.php
@@ -137,6 +137,11 @@ class PDFShift
                 if (!empty($body['message'])) {
                     throw new Exceptions\InvalidRequestException($body['message'], $body);
                 }
+                
+                if (isset($body['error']) && is_string($body['error'])) {
+                    throw new Exceptions\InvalidRequestException($body['error'], $body);
+                }
+                
                 reset($body['errors']);
                 $key = key($body['errors']);
                 $message = $key.' : '.$body['errors'][$key][0];


### PR DESCRIPTION
Body Return Data:
array:4 [
  "code" => 400,
  "error" => "Document size too big. Limit of 1Mb, document is 1.69Mb",
  "identifier" => "A99",
  "success" => false
]